### PR TITLE
add functionality of parsing log and updating metrics for influxwatch

### DIFF
--- a/cmd/influxwatch/log.go
+++ b/cmd/influxwatch/log.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/funkygao/gafka"
+	log "github.com/funkygao/log4go"
+)
+
+func setupLogging(logFile, logLevel, crashLogFile string) {
+	level := log.DEBUG
+	switch logLevel {
+	case "info":
+		level = log.INFO
+
+	case "warn":
+		level = log.WARNING
+
+	case "error":
+		level = log.ERROR
+
+	case "debug":
+		level = log.DEBUG
+
+	case "trace":
+		level = log.TRACE
+
+	case "alarm":
+		level = log.ALARM
+	}
+
+	for _, filter := range log.Global {
+		filter.Level = level
+	}
+
+	log.LogBufferLength = 32 // default 32, chan cap
+
+	if logFile == "stdout" {
+		log.AddFilter("stdout", level, log.NewConsoleLogWriter())
+	} else {
+		log.DeleteFilter("stdout")
+
+		filer := log.NewFileLogWriter(logFile, true, true, 0)
+		filer.SetFormat("[%d %T] [%L] (%S) %M")
+		filer.SetRotateSize(0)
+		filer.SetRotateKeepDuration(time.Hour * 24 * 30)
+		filer.SetRotateLines(0)
+		filer.SetRotateDaily(true)
+		log.AddFilter("file", level, filer)
+	}
+
+	if crashLogFile != "" {
+		f, err := os.OpenFile(crashLogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			panic(err)
+		}
+
+		syscall.Dup2(int(f.Fd()), int(os.Stdout.Fd()))
+		syscall.Dup2(int(f.Fd()), int(os.Stderr.Fd()))
+		fmt.Fprintf(os.Stderr, "\n%s %s (build: %s)\n===================\n",
+			time.Now().String(),
+			gafka.Version, gafka.BuildId)
+	}
+
+}

--- a/cmd/influxwatch/main.go
+++ b/cmd/influxwatch/main.go
@@ -2,31 +2,93 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"runtime/debug"
+	"syscall"
 	"time"
 
+	"strconv"
+
+	"strings"
+
+	"github.com/funkygao/gafka"
 	"github.com/funkygao/gafka/ctx"
 	"github.com/funkygao/gafka/telemetry"
 	"github.com/funkygao/gafka/telemetry/influxdb"
 	"github.com/funkygao/go-metrics"
 	gio "github.com/funkygao/golib/io"
+	"github.com/funkygao/golib/signal"
+	log "github.com/funkygao/log4go"
+	"github.com/satyrius/gonx"
 )
 
 var (
-	z string
+	z          string
+	v          bool
+	logfile    string
+	parser     *gonx.Parser
+	httpdRegex = regexp.MustCompile(`^\[httpd\]`) //log begin with [httpd]
+
+	ErrInvalidLogFormatLine = errors.New("invalid log format line")
+)
+
+const (
+	defaultLogfile = "influxwatch.log"
 )
 
 func init() {
 	ctx.LoadFromHome()
 
 	flag.StringVar(&z, "z", ctx.DefaultZone(), "zone")
+	flag.BoolVar(&v, "version", false, "version")
+	flag.StringVar(&logfile, "log", defaultLogfile, "")
 	flag.Parse()
+
+	//init log parser
+	httpdFormat := "[$prefix] $remote_addr $remote_log_name $remote_user [$start_time] \"$request\" $status $resp_bytes \"$referer\" \"$user_agent\" $req_id $time_elapsed"
+	parser = gonx.NewParser(httpdFormat)
 }
 
 func main() {
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Println(err)
+			debug.PrintStack()
+		}
+	}()
+
+	if v {
+		fmt.Fprintf(os.Stderr, "%s-%s\n", gafka.Version, gafka.BuildId)
+		os.Exit(0)
+	}
+
+	//config log
+	setupLogging(logfile, "trace", "panic")
+
+	log.Info("influxwatch[%s] starting...", gafka.BuildId)
+
+	startedAt := time.Now()
+	closed := make(chan struct{})
+	signal.RegisterHandler(func(sig os.Signal) {
+		log.Info("influxwatch[%s] got signal: %s", gafka.BuildId, strings.ToUpper(sig.String()))
+
+		if telemetry.Default != nil {
+			log.Info("stopping telemetry and flush all metrics...")
+			telemetry.Default.Stop()
+		}
+
+		log.Info("influxwatch[%s] shutdown complete", gafka.BuildId)
+		log.Info("influxwatch[%s] %s bye!", gafka.BuildId, time.Since(startedAt))
+
+		//notify mainline to exit
+		close(closed)
+	}, syscall.SIGINT, syscall.SIGTERM)
+
 	setupTelemetry()
 
 	postLatency := metrics.NewRegisteredHistogram("influxdb.latency.post", nil, metrics.NewExpDecaySample(1028, 0.015))
@@ -36,29 +98,38 @@ func main() {
 
 	reader := bufio.NewReader(os.Stdin)
 	for {
-		line, err := gio.ReadLine(reader)
-		if err != nil {
-			if err == io.EOF {
-				break
-			} else {
-				fmt.Println(err)
+
+		select {
+		case <-closed:
+			//exit
+			return
+
+		default:
+			line, err := gio.ReadLine(reader)
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					log.Info("%v", err)
+					continue
+				}
+			}
+
+			pl, gl, ps, gs, m, err := parseLine(line)
+			if err != nil {
+				log.Info("%v", err)
 				continue
 			}
-		}
 
-		pl, gl, ps, gs, err := parseLine(line)
-		if err != nil {
-			fmt.Println(err)
-			continue
+			if m == "POST" {
+				postLatency.Update(pl)
+				postSize.Update(ps)
+			} else if m == "GET" {
+				getLatency.Update(gl)
+				getSize.Update(gs)
+			}
 		}
-
-		postLatency.Update(pl)
-		getLatency.Update(gl)
-		postSize.Update(ps)
-		getSize.Update(gs)
 	}
-
-	fmt.Println("bye!")
 }
 
 func setupTelemetry() {
@@ -73,6 +144,57 @@ func setupTelemetry() {
 }
 
 // line e,g. [httpd] 10.213.1.223 - admin [11/Jan/2017:09:00:23 +0800] "GET /query?db=kfk_prod&epoch=ms&q=SELECT+sum%28%22m5%22%29+FROM+%22pub.qps.meter%22+WHERE+time+%3E+now%28%29+-+24h+GROUP+BY+time%281m%29+fill%28null%29%3B%0ASELECT+sum%28%22m5%22%29+FROM+%22consumer.qps.meter%22+WHERE+time+%3E+now%28%29+-+24h+GROUP+BY+time%281m%29+fill%28null%29 HTTP/1.1" 200 37369 "http://console.mycorp.com/dashboard/db/kafka-pub" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" 54e84336-d799-11e6-a82d-000000000000 6369522
-func parseLine(line []byte) (postLatency, getLatency, postSize, getSize int64, err error) {
+func parseLine(line []byte) (postLatency, getLatency, postSize, getSize int64, method string, err error) {
+
+	//only the line begins with [httpd] is valid
+	if !httpdRegex.Match(line) {
+		return 0, 0, 0, 0, "", ErrInvalidLogFormatLine
+	}
+
+	entry, err := parser.ParseString(string(line))
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+
+	//get all fields we need
+	respSizeStr, err := entry.Field("resp_bytes")
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+
+	respSize, err := strconv.ParseInt(respSizeStr, 10, 64)
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+
+	latencyStr, err := entry.Field("time_elapsed")
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+
+	latency, err := strconv.ParseInt(latencyStr, 10, 64)
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+
+	req, err := entry.Field("request")
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+
+	method = getMethod(req)
+	if method == "POST" {
+		postLatency = latency //microsecond
+		postSize = respSize   //bytes
+	} else if method == "GET" {
+		getLatency = latency //microsecond
+		getSize = respSize   //bytes
+	}
 	return
+}
+
+func getMethod(req string) string {
+	//req = r.Method+" "+uri+" "+r.Proto
+	items := strings.Split(req, " ")
+	return strings.ToUpper(items[0])
 }

--- a/cmd/influxwatch/main.go
+++ b/cmd/influxwatch/main.go
@@ -134,6 +134,12 @@ func main() {
 
 func setupTelemetry() {
 	zone := ctx.Zone(z)
+
+	//add "http://" if not exist
+	if !strings.HasPrefix(zone.InfluxAddr, "http:") {
+		zone.InfluxAddr = fmt.Sprintf("http://%s", zone.InfluxAddr)
+	}
+
 	cf, err := influxdb.NewConfig(zone.InfluxAddr, "pubsub", "", "", time.Minute)
 	if err != nil {
 		panic(err)

--- a/cmd/influxwatch/main.go
+++ b/cmd/influxwatch/main.go
@@ -208,7 +208,7 @@ func parseLine(line []byte) (postLatency, getLatency, postSize, getSize int64, m
 func getMethod(req string) (string, string) {
 	//req = r.Method+" "+uri+" "+r.Proto
 	items := strings.Split(req, " ")
-	return strings.ToUpper(items[0]), strings.ToUpper(items[1])
+	return strings.ToUpper(items[0]), items[1]
 }
 
 func isTargetReq(method, uri string) (err error) {


### PR DESCRIPTION
influxaddr format in .gafka.cf for each zone should be "http://127.0.0.1:8086"  not "127.0.0.1:8086"