### PR TITLE
add kfk monitor interface 7: find group's info with topics which are …

### DIFF
--- a/cmd/kguard/monitor/api.go
+++ b/cmd/kguard/monitor/api.go
@@ -23,6 +23,7 @@ func (this *Monitor) setupRoutes() {
 	this.router.POST("/kfk/clusters", this.kfkClustersHandler)
 	this.router.POST("/kfk/topics", this.kfkTopicsHandler)
 	this.router.POST("/kfk/topicsGroups", this.kfkTopicsGroupsHandler)
+	this.router.POST("/kfk/groupsWithTopics", this.kfkGroupsWithTopicsHandler)
 	this.router.GET("/zk/cluster", this.zkClusterHandler)
 	this.router.POST("/kfk/hosts", this.hostsHandler)
 	this.router.PUT("/kfk/offset/:cluster/:topic/:group/:partition", this.resetOffsetHandler)


### PR DESCRIPTION
…subscribed by this group

// 1. specify cluster or all clusters, return error msg if cluster not exist
// 2. specify groups or all groups, return error msg if group not exist
// 3. specify topic or all topics, return error if topic not exist or group not on this topic
// 4. return topics oldest and latest offset for each partition
// 5. return group's offset on topic for each partition and last commit time
// 6. return online group memId and up time